### PR TITLE
Add FileBufferPart multipart form part

### DIFF
--- a/include/asyncnet/MultipartForms.hpp
+++ b/include/asyncnet/MultipartForms.hpp
@@ -1,0 +1,60 @@
+#pragma once
+#include <curlpp/Form.hpp>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace asyncnet {
+	/**
+	* A multipart/form-data file part whose contents come from an in-memory
+	* buffer rather than a file on disk (unlike @ref curlpp::FormParts::File).
+	*/
+	class FileBufferPart : public curlpp::FormPart {
+	public:
+
+		/**
+		* initialize a File part
+		* @param name The name of the field
+		* @param content The content of the field
+		* @param filename The filename reported for the part
+		*/
+		FileBufferPart(
+			std::string name,
+			std::vector<uint8_t> content,
+			std::string filename
+		);
+
+		/**
+		* initialize a File part
+		* @param name The name of the field
+		* @param content The content of the field
+		* @param filename The filename reported for the part
+		* @param content_type MIME type of the content
+		*/
+		FileBufferPart(
+			std::string name,
+			std::vector<uint8_t> content,
+			std::string filename,
+			std::string content_type
+		);
+
+		virtual ~FileBufferPart() override = default;
+
+		/**
+		* This function will return a copy of the instance.
+		*/
+		virtual FileBufferPart* clone() const override;
+
+	private:
+
+		void add(
+			curl_httppost** first,
+			curl_httppost** last
+		) override;
+
+		const std::vector<uint8_t> content_;
+		const std::string filename_;
+		const std::string content_type_;
+	};
+}

--- a/src/MultipartForms.cpp
+++ b/src/MultipartForms.cpp
@@ -1,0 +1,68 @@
+#include <asyncnet/MultipartForms.hpp>
+
+namespace asyncnet {
+	FileBufferPart::FileBufferPart(
+		std::string name,
+		std::vector<uint8_t> content,
+		std::string filename
+	) :
+		FormPart(std::move(name)),
+		content_(std::move(content)),
+		filename_(std::move(filename))
+	{
+
+	}
+
+	FileBufferPart::FileBufferPart(
+		std::string name,
+		std::vector<uint8_t> content,
+		std::string filename,
+		std::string content_type
+	) :
+		FormPart(std::move(name)),
+		content_(std::move(content)),
+		filename_(std::move(filename)),
+		content_type_(std::move(content_type))
+	{
+
+	}
+
+	FileBufferPart* FileBufferPart::clone() const {
+		return new FileBufferPart(*this);
+	}
+
+	void FileBufferPart::add(curl_httppost** first, curl_httppost** last) {
+		if (content_type_.empty()) {
+			curl_formadd(
+				first,
+				last,
+				CURLFORM_PTRNAME,
+				mName.c_str(),
+				CURLFORM_BUFFER,
+				filename_.c_str(),
+				CURLFORM_BUFFERPTR,
+				content_.data(),
+				CURLFORM_BUFFERLENGTH,
+				content_.size(),
+				CURLFORM_END
+			);
+		}
+		else {
+			curl_formadd(
+				first,
+				last,
+				CURLFORM_PTRNAME,
+				mName.c_str(),
+				CURLFORM_BUFFER,
+				filename_.c_str(),
+				CURLFORM_BUFFERPTR,
+				content_.data(),
+				CURLFORM_BUFFERLENGTH,
+				content_.size(),
+				CURLFORM_CONTENTTYPE,
+				content_type_.c_str(),
+				CURLFORM_END
+			);
+		}
+	}
+}


### PR DESCRIPTION
Adds `asyncnet::FileBufferPart` — a `multipart/form-data` file part whose
contents come from an in-memory buffer (`std::vector<uint8_t>`) rather than a
file on disk. `curlpp::FormParts::File` can only read from a path, so uploading
a generated/received buffer as a named file part was not possible before.

The part is emitted via `curl_formadd` using
`CURLFORM_BUFFER` / `CURLFORM_BUFFERPTR` / `CURLFORM_BUFFERLENGTH`, with an
optional `CURLFORM_CONTENTTYPE`.

Ported from the app tree into libasyncnet (`projectview` → `asyncnet` namespace,
`<asyncnet/MultipartForms.hpp>` include path).

### Bug fix

The content-type check in `add()` was inverted: `CURLFORM_CONTENTTYPE` was passed
only when `content_type_` was **empty** and omitted when it was **set** — exactly
backwards. Now the MIME type is attached when provided.

### Tests

`asyncnetTests` builds clean and passes (73 assertions in 25 test cases, network
tests off). No dedicated form test yet — sending a real multipart request needs
the planned local test server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)