### PR TITLE
Use std::string for FileBufferPart buffer

### DIFF
--- a/include/asyncnet/MultipartForms.hpp
+++ b/include/asyncnet/MultipartForms.hpp
@@ -1,9 +1,7 @@
 #pragma once
 #include <curlpp/Form.hpp>
 
-#include <cstdint>
 #include <string>
-#include <vector>
 
 namespace asyncnet {
 	/**
@@ -21,7 +19,7 @@ namespace asyncnet {
 		*/
 		FileBufferPart(
 			std::string name,
-			std::vector<uint8_t> content,
+			std::string content,
 			std::string filename
 		);
 
@@ -34,7 +32,7 @@ namespace asyncnet {
 		*/
 		FileBufferPart(
 			std::string name,
-			std::vector<uint8_t> content,
+			std::string content,
 			std::string filename,
 			std::string content_type
 		);
@@ -53,7 +51,7 @@ namespace asyncnet {
 			curl_httppost** last
 		) override;
 
-		const std::vector<uint8_t> content_;
+		const std::string content_;
 		const std::string filename_;
 		const std::string content_type_;
 	};

--- a/src/MultipartForms.cpp
+++ b/src/MultipartForms.cpp
@@ -3,7 +3,7 @@
 namespace asyncnet {
 	FileBufferPart::FileBufferPart(
 		std::string name,
-		std::vector<uint8_t> content,
+		std::string content,
 		std::string filename
 	) :
 		FormPart(std::move(name)),
@@ -15,7 +15,7 @@ namespace asyncnet {
 
 	FileBufferPart::FileBufferPart(
 		std::string name,
-		std::vector<uint8_t> content,
+		std::string content,
 		std::string filename,
 		std::string content_type
 	) :


### PR DESCRIPTION
Store `FileBufferPart`'s content as `std::string` instead of
`std::vector<uint8_t>`.

`curl_formadd` still receives the raw bytes through `content_.data()` /
`content_.size()`, so upload behaviour is unchanged. This drops the
`<cstdint>` / `<vector>` includes and matches how callers usually hold the
payload.

Builds clean (`asyncnet` library and tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)