### PR TITLE
Fix Requestor executor shared-ownership lifetime

### DIFF
--- a/include/asyncnet/Requestor.hpp
+++ b/include/asyncnet/Requestor.hpp
@@ -8,7 +8,7 @@
 
 namespace asyncnet {
 
-	class Requestor : CurlMulti, public RequestPerformer, public std::enable_shared_from_this<Requestor> {
+	class Requestor : CurlMulti, public RequestPerformer {
 		struct private_constructor { explicit private_constructor() = default; };
 
 	public:
@@ -61,8 +61,10 @@ namespace asyncnet {
 
 		/**
 		 * Requestor's thread body function
+		 * @param shared_this Shared ownership of this Requestor, kept alive for the
+		 *        executor's lifetime; when it becomes the sole owner the executor shuts down
 		 */
-		coro::task<void> yield_executor();
+		coro::task<void> yield_executor(std::shared_ptr<Requestor> shared_this);
 
 		int timeout_ms_;
 		std::atomic_bool shutting_down_;

--- a/src/Requestor.cpp
+++ b/src/Requestor.cpp
@@ -52,14 +52,18 @@ namespace asyncnet {
 
 	std::shared_ptr<Requestor> Requestor::make_shared() {
 		auto ptr = std::make_shared<Requestor>(private_constructor{});
-		ptr->yield_thread_ = std::thread([ptr = ptr.get()] { coro::sync_wait(ptr->yield_executor()); });
+		ptr->yield_thread_ = std::thread([ptr]() mutable {
+			// Take the raw self pointer before moving ptr into the coroutine frame,
+			// so the call target does not depend on argument evaluation order.
+			Requestor* self = ptr.get();
+			coro::sync_wait(self->yield_executor(std::move(ptr)));
+		});
 		return ptr;
 	}
 
-	coro::task<void> Requestor::yield_executor() {
-		auto p = shared_from_this();
+	coro::task<void> Requestor::yield_executor(std::shared_ptr<Requestor> shared_this) {
 		while (!shutting_down_.load(std::memory_order_acquire)) {
-			if (p.use_count() == 1) {
+			if (shared_this.use_count() == 1) {
 				// there is only executor referencing the object, so shutdown
 				// TODO: use coroutine features to shutdown
 				shutdown();


### PR DESCRIPTION
Fixes a startup race in `Requestor::make_shared()`.

The executor thread was spawned capturing only a **raw** pointer and then called
`shared_from_this()` inside `yield_executor()`. If the caller dropped the
returned `shared_ptr` before the thread reached `shared_from_this()`, that call
hit `bad_weak_ptr` / a dangling object.

### Fix

- Capture the `shared_ptr` in the thread lambda and `std::move` it into
  `yield_executor(std::shared_ptr<Requestor> shared_this)`, which now owns the
  object for the executor's lifetime and drives the `use_count() == 1` shutdown
  check.
- The lambda is `mutable` so the `std::move` actually moves. Without `mutable`
  it degrades to a copy: the captured `shared_ptr` stays alive for the whole
  run, `use_count()` never reaches 1, and `shutdown()` would never fire — a
  second latent bug.
- Grab the raw self pointer into a local before moving `ptr` into the coroutine
  frame, so the call target doesn't rely on argument evaluation order.
- Drop the now-unused `enable_shared_from_this` base.

Builds clean; tests pass (73 assertions in 25 test cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)