### PR TITLE
feat(response): capture response headers and effective URL

### DIFF
--- a/include/asyncnet/Response.hpp
+++ b/include/asyncnet/Response.hpp
@@ -1,13 +1,14 @@
 #pragma once
 #include <curlpp/Easy.hpp>
 #include <sstream>
+#include <string>
 #include <optional>
 
 namespace asyncnet {
 	class Response {
 	public:
-		explicit Response(curlpp::Easy&& handle);
-		explicit Response(curlpp::Easy&& handle, std::ostringstream&& text_stream);
+		explicit Response(curlpp::Easy&& handle, std::string header_block = {});
+		explicit Response(curlpp::Easy&& handle, std::ostringstream&& text_stream, std::string header_block = {});
 
 		Response(const Response& other) = delete;
 		Response(Response&& other) = default;
@@ -30,8 +31,30 @@ namespace asyncnet {
 		 */
 		std::string get_text() &&;
 
+		/**
+		 * Raw header block of the final response: CRLF-delimited "Name: Value"
+		 * lines as received. On a redirect chain only the last response's headers
+		 * are kept (intermediate responses' headers are dropped), and the status
+		 * line ("HTTP/...") is not included. Empty if the server sent no headers.
+		 * @return Response header block
+		 */
+		const std::string& get_header_block() const &;
+
+		/**
+		 * Move the raw header block of the final response.
+		 * @return Response header block
+		 */
+		std::string get_header_block() &&;
+
+		/**
+		 * Effective URL after following any redirects (CURLINFO_EFFECTIVE_URL).
+		 * @return Final URL the response came from
+		 */
+		std::string get_effective_url() const;
+
 	private:
 		curlpp::Easy handle_;
 		std::optional<std::ostringstream> stream_;
+		std::string header_block_;
 	};
 }

--- a/src/CurlMulti.cpp
+++ b/src/CurlMulti.cpp
@@ -7,6 +7,8 @@
 #include <curlpp/Options.hpp>
 #include <numeric>
 #include <ranges>
+#include <string>
+#include <string_view>
 
 using std::views::iota;
 
@@ -100,11 +102,33 @@ namespace asyncnet {
 		return promise.stop_requested() ? curl_cancel_request : curl_continue_request;
 	}
 
+	// Accumulate the final response's header block. curl invokes this once per
+	// header line (with a trailing CRLF) for every response in a redirect chain;
+	// clearing on each new status line ("HTTP/...") keeps only the last response's
+	// headers, and the status line itself is dropped so only "Name: Value" lines remain.
+	static size_t header_callback(char* buffer, size_t size, size_t nitems, void* userdata) {
+		const size_t total = size * nitems;
+		auto& block = *static_cast<std::string*>(userdata);
+		std::string_view line(buffer, total);
+		if (line.starts_with("HTTP/")) {
+			block.clear();
+		} else {
+			block.append(line);
+		}
+		return total;
+	}
+
 	NetworkTask<Response> CurlMulti::perform_handle(curlpp::Easy handle, std::ostream* output_stream) {
 		NetworkPromise<Response>& promise = co_await awaitables::get_self;
 		curl_easy_setopt(handle.getHandle(), CURLOPT_XFERINFOFUNCTION, &xferinfo_callback);
 		curl_easy_setopt(handle.getHandle(), CURLOPT_XFERINFODATA, &promise);
 		handle.setOpt(curlpp::options::NoProgress(false));
+
+		// Capture the response header block into a buffer owned by this coroutine
+		// frame (stays alive across the suspend, like the body sink below).
+		std::string header_block;
+		curl_easy_setopt(handle.getHandle(), CURLOPT_HEADERFUNCTION, &header_callback);
+		curl_easy_setopt(handle.getHandle(), CURLOPT_HEADERDATA, &header_block);
 
 		// Route the body either into the caller's sink (streamed, not buffered) or,
 		// when none is given, into an internal buffer owned by this coroutine frame.
@@ -132,9 +156,9 @@ namespace asyncnet {
 		curlpp::libcurlRuntimeAssert("Multi network request failed", exit_code);
 
 		if (owned_stream) {
-			co_return Response(std::move(handle), std::move(owned_stream.value()));
+			co_return Response(std::move(handle), std::move(owned_stream.value()), std::move(header_block));
 		}
-		co_return Response(std::move(handle));
+		co_return Response(std::move(handle), std::move(header_block));
 	}
 
 	CURLM* CurlMulti::get_handle() const noexcept {

--- a/src/Response.cpp
+++ b/src/Response.cpp
@@ -1,11 +1,13 @@
 #include <asyncnet/Response.hpp>
 
 namespace asyncnet{
-	Response::Response(curlpp::Easy&& handle) : handle_(std::move(handle)) {
+	Response::Response(curlpp::Easy&& handle, std::string header_block)
+		: handle_(std::move(handle)), header_block_(std::move(header_block)) {
 
 	}
 
-	Response::Response(curlpp::Easy&& handle, std::ostringstream&& stream) : handle_(std::move(handle)), stream_(std::move(stream)) {
+	Response::Response(curlpp::Easy&& handle, std::ostringstream&& stream, std::string header_block)
+		: handle_(std::move(handle)), stream_(std::move(stream)), header_block_(std::move(header_block)) {
 
 	}
 
@@ -31,5 +33,19 @@ namespace asyncnet{
 		else {
 			return "";
 		}
+	}
+
+	const std::string& Response::get_header_block() const & {
+		return header_block_;
+	}
+
+	std::string Response::get_header_block() && {
+		return std::move(header_block_);
+	}
+
+	std::string Response::get_effective_url() const {
+		std::string url;
+		handle_.getCurlHandle().getInfo(CURLINFO_EFFECTIVE_URL, url);
+		return url;
 	}
 }


### PR DESCRIPTION
## What
`asyncnet::Response` now surfaces response headers and the effective URL:
- `get_header_block()` — raw header block of the final response (CRLF `Name: Value` lines; redirect responses' headers dropped, status line excluded).
- `get_effective_url()` — `CURLINFO_EFFECTIVE_URL`.

`CurlMulti::perform_handle` installs a `CURLOPT_HEADERFUNCTION` callback that writes into a coroutine-frame buffer (same lifetime pattern as the body sink). The callback clears the buffer on each `HTTP/` status line, so only the last response's headers remain across a redirect chain.

## Why
Unblocks libaniparse populating `ResponseData.headers` / `effective_url` (the `Location` escape hatch and ETag caching). HTTP header parsing stays in the consumer; asyncnet only hands over the raw block, keeping the transport thin.

## Notes
- Always-on capture; cost is a few small string appends.
- Single construction site (`CurlMulti`) — no other performer builds `Response`, so this is the only wiring point.
- Verified: asyncnet library builds (MSVC/Ninja, x64-debug).
